### PR TITLE
Fix `TypeError: stringify cannot serialize cyclic structures`

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -65,7 +65,9 @@
 			if (new Date() < expirationDate) {
 				expirationObject[key] = expirationDate;
 				storageMethod.setItem( namespace+'storageModuleExpirationDates', JSON.stringify(expirationObject) );
-				storageMethod.setItem(key, JSON.stringify(activeObjects[key]));
+				storageMethod.setItem(key, JSON.stringify(activeObjects[key], function (k, v) {
+					return activeObjects[key].hasOwnProperty(k);
+				}));
 			} else {
 				expire( key, expirationObject, activeObjects, storageMethod );
 			}


### PR DESCRIPTION
In mobile safari, `JSON.stringify` will attempt to serialize objects and their prototypes in entirety. This produces the error`stringify cannot serialize cyclic structures`. In order to avoid this, this pull request uses the replacer function to exclude prototype properties, and only serialize own properties.

This also has been noted to happen in Chrome and other browsers.
